### PR TITLE
enable users to specify JS executable name using JS_CMD environment variable

### DIFF
--- a/bin/jslint
+++ b/bin/jslint
@@ -7,7 +7,11 @@ if RUBY_PLATFORM =~ /win32/i
   runjslint_ext = 'wsf'
   plugin_path = File.join(ENV['HOME'], 'vimfiles')
 else
-  js_cmd = 'js'
+  if ENV['JS_CMD']
+    js_cmd = ENV['JS_CMD']
+  else
+    js_cmd = 'js'
+  end
   runjslint_ext = 'js'
   plugin_path = File.join(ENV['HOME'], '.vim')
 end

--- a/ftplugin/javascript/jslint.vim
+++ b/ftplugin/javascript/jslint.vim
@@ -55,7 +55,9 @@ if has("win32")
   let s:runjslint_ext = 'wsf'
 else
   let s:runjslint_ext = 'js'
-  if executable('/System/Library/Frameworks/JavaScriptCore.framework/Resources/jsc')
+  if exists("$JS_CMD")
+    let s:cmd = "$JS_CMD"
+  elseif executable('/System/Library/Frameworks/JavaScriptCore.framework/Resources/jsc')
     let s:cmd = '/System/Library/Frameworks/JavaScriptCore.framework/Resources/jsc'
   elseif executable('node')
     let s:cmd = 'node'


### PR DESCRIPTION
It seems like it would be useful for savvy users to be able to specify the name of whatever JS executable they want in their environment, using and environment variable named JS_CMD or whatever. That way, they don't need to edit any of the jslint.vim files, and can switch among different JS executables just by changing the environment variable.
