### PR TITLE
quickfix support

### DIFF
--- a/ftplugin/javascript/jslint.vim
+++ b/ftplugin/javascript/jslint.vim
@@ -164,7 +164,7 @@ function! s:JSLint()
       let l:qf_item.filename = expand('%')
       let l:qf_item.lnum = l:line
       let l:qf_item.text = b:parts[3]
-      let l:qf_item.type = 'E'
+      let l:qf_item.type = 'W'
 
       " Add line to quickfix list
       call add(b:qf_list, l:qf_item)

--- a/ftplugin/javascript/jslint.vim
+++ b/ftplugin/javascript/jslint.vim
@@ -143,15 +143,21 @@ function! s:JSLint()
 
   for error in split(b:jslint_output, "\n")
     " Match {line}:{char}:{message}
-    let b:parts = matchlist(error, "\\(\\d\\+\\):\\(\\d\\+\\):\\(.*\\)")
+    let b:parts = matchlist(error, "\\(\\d\\+\\):\\(\\d\\+\\):\\([A-Z]\\+\\):\\(.*\\)")
     if !empty(b:parts)
       let l:line = b:parts[1] + (b:firstline - 1 - len(s:jslintrc)) " Get line relative to selection
+      let l:errorMessage = b:parts[4]
 
-        " Store the error for an error under the cursor
+      " Store the error for an error under the cursor
       let s:matchDict = {}
       let s:matchDict['lineNum'] = l:line
-      let s:matchDict['message'] = b:parts[3]
+      let s:matchDict['message'] = l:errorMessage
       let b:matchedlines[l:line] = s:matchDict
+      if b:parts[3] == 'ERROR'
+          let l:errorType = 'E'
+      else
+          let l:errorType = 'W'
+      endif
       if g:JSLintHighlightErrorLine == 1
           let s:mID = matchadd('JSLintError', '\%' . l:line . 'l\S.*\(\S\|$\)')
       endif
@@ -163,8 +169,8 @@ function! s:JSLint()
       let l:qf_item.bufnr = bufnr('%')
       let l:qf_item.filename = expand('%')
       let l:qf_item.lnum = l:line
-      let l:qf_item.text = b:parts[3]
-      let l:qf_item.type = 'W'
+      let l:qf_item.text = l:errorMessage
+      let l:qf_item.type = l:errorType
 
       " Add line to quickfix list
       call add(b:qf_list, l:qf_item)

--- a/ftplugin/javascript/jslint/runjslint.js
+++ b/ftplugin/javascript/jslint/runjslint.js
@@ -73,14 +73,24 @@ readSTDIN(function(body) {
     var ok = JSLINT(body)
       , i
       , error
-      , errorCount;
+      , errorType
+      , nextError
+      , errorCount
+      , WARN = 'WARNING'
+      , ERROR = 'ERROR';
 
     if (!ok) {
         errorCount = JSLINT.errors.length;
         for (i = 0; i < errorCount; i += 1) {
             error = JSLINT.errors[i];
+            errorType = WARN;
+            nextError = i < errorCount ? JSLINT.errors[i+1] : null;
             if (error && error.reason && error.reason.match(/^Stopping/) === null) {
-                print([error.line, error.character, error.reason].join(":"));
+                // If jslint stops next, this was an actual error
+                if (nextError && nextError.reason && nextError.reason.match(/^Stopping/) !== null) {
+                    errorType = ERROR;
+                }
+                print([error.line, error.character, errorType, error.reason].join(":"));
             }
         }
     }


### PR DESCRIPTION
This commit adds quickfix support to your jslint vim plugin. The format is strongly influenced (ha) by the pyflakes vim plugin, which made me fall in love with vim quickfix.

Cheers!
- Ben
