### PR TITLE
skip a shebang (#!) first line, e.g. for a node.js script

### DIFF
--- a/ftplugin/javascript/jslint.vim
+++ b/ftplugin/javascript/jslint.vim
@@ -126,7 +126,12 @@ function! s:JSLint()
 
   " Detect range
   if a:firstline == a:lastline
-    let b:firstline = 1
+    " Skip a possible shebang line, e.g. for node.js script.
+    if getline(1)[0:1] == "#!"
+      let b:firstline = 2
+    else
+      let b:firstline = 1
+    endif
     let b:lastline = '$'
   else 
     let b:firstline = a:firstline


### PR DESCRIPTION
If you would like to take this patch, that would be cool. I've been starting to write node.js scripts using a shebang line. Without this patch one cannot use jslint.vim on those files.

Cheers,
Trent
