### PR TITLE
Fix jslint.vim for non-POSIX shells

### DIFF
--- a/ftplugin/javascript/jslint.vim
+++ b/ftplugin/javascript/jslint.vim
@@ -151,7 +151,10 @@ function! s:JSLint()
   if len(lines) == 0
     return
   endif
+  let old_shell = &shell
+  let &shell = '/bin/bash'
   let b:jslint_output = system(s:cmd, lines . "\n")
+  let &shell = old_shell
   if v:shell_error
     echoerr 'could not invoke JSLint!'
     let b:jslint_disabled = 1


### PR DESCRIPTION
The input and output redirection used here causes the shell I use, fish, to behave improperly since parentheses have a different meaning in fish than in bash.
