### PR TITLE
Feature toggle echo

### DIFF
--- a/ftplugin/javascript/jslint.vim
+++ b/ftplugin/javascript/jslint.vim
@@ -47,7 +47,8 @@ if !exists(":JSLintUpdate")
   command JSLintUpdate :call s:JSLintUpdate()
 endif
 if !exists(":JSLintToggle")
-  command JSLintToggle :let b:jslint_disabled = exists('b:jslint_disabled') ? b:jslint_disabled ? 0 : 1 : 1
+  command JSLintToggle exec ":let b:jslint_disabled = exists('b:jslint_disabled') ? b:jslint_disabled ? 0 : 1 : 1" |
+    \                  echo 'JSLint ' . ['enabled', 'disabled'][b:jslint_disabled] . '.'
 endif
 
 noremap <buffer><silent> dd dd:JSLintUpdate<CR>


### PR DESCRIPTION
This is just a trivial change that I find makes it easier to understand what jslint.vim was doing, especially when the syntax colouring is disabled.  The change causes the disabled/enabled state to be echoed by the `JSLintToggle` command.

If for some reason it might important to not make any noise, let me know and I will refactor it to use a `g:JSLint...` variable.
