### PR TITLE
Feature update profiles

### DIFF
--- a/ftplugin/javascript/jslint.vim
+++ b/ftplugin/javascript/jslint.vim
@@ -145,6 +145,9 @@ if !exists('s:update')
   function s:CompleteUpdateProfiles(...)
     return join(keys(s:update.profiles), "\n")
   endfunction
+endif
+
+if exists(':JSLintUpdateMode') != 2
   command -buffer -complete=custom,s:CompleteUpdateProfiles -nargs=?
         \ JSLintUpdateMode
         \ exec <q-args> == ''

--- a/ftplugin/javascript/jslint.vim
+++ b/ftplugin/javascript/jslint.vim
@@ -135,6 +135,8 @@ if !exists('s:update')
       au BufWrite <buffer> call s:JSLint()
 
       au CursorMoved <buffer> call s:GetJSLintMessage()
+
+      call s:JSLint()
     endfunction
 
 
@@ -149,8 +151,6 @@ if !exists('s:update')
         \   ? 'echo s:update.GetProfile()[0]'
         \   : 'call s:update.SelectProfile(<f-args>)'
 endif
-
-exec 'JSLintUpdateMode' g:JSLintUpdateProfile
 
 
 if !exists("*s:JSLintUpdate")
@@ -378,3 +378,5 @@ if !exists("*s:ActivateJSLintQuickFixWindow")
     endfunction
 endif
 
+
+exec 'JSLintUpdateMode' g:JSLintUpdateProfile

--- a/ftplugin/javascript/jslint.vim
+++ b/ftplugin/javascript/jslint.vim
@@ -7,6 +7,13 @@
 " let g:JSLintHighlightErrorLine = 0
 " in your .vimrc
 "
+" g:JSLintUpdateProfile [String; default='thorough']:
+"   Determines when updates to JSLint's state will happen.
+"   'thorough': Update on virtually all events which can change the buffer.
+"   'onwrite':  Just update when the buffer is written.
+"   This variable determines the setting for new buffers;
+"   to choose an update mode for existing buffers, use `:JSLintUpdateMode`.
+
 if exists("b:did_jslint_plugin")
   finish
 else
@@ -15,26 +22,136 @@ endif
 
 let s:install_dir = expand('<sfile>:p:h')
 
-au BufLeave <buffer> call s:JSLintClear()
-
-au BufEnter <buffer> call s:JSLint()
-au InsertLeave <buffer> call s:JSLint()
-"au InsertEnter <buffer> call s:JSLint()
-au BufWritePost <buffer> call s:JSLint()
-
-" due to http://tech.groups.yahoo.com/group/vimdev/message/52115
-if(!has("win32") || v:version>702)
-  au CursorHold <buffer> call s:JSLint()
-  au CursorHoldI <buffer> call s:JSLint()
-
-  au CursorHold <buffer> call s:GetJSLintMessage()
-endif
-
-au CursorMoved <buffer> call s:GetJSLintMessage()
 
 if !exists("g:JSLintHighlightErrorLine")
   let g:JSLintHighlightErrorLine = 1
 endif
+
+if !exists('g:JSLintUpdateProfile')
+  let g:JSLintUpdateProfile = 'thorough'
+endif
+
+
+if !exists('s:update')
+  " Controls the overall update functionality:
+  " which autocommands and mappings will trigger hooks.
+  " The command JSLintUpdateMode
+  " controls which update mode is used for the current buffer.
+  " g:JSLintUpdateProfile will be used by default.
+  let s:update = {}
+
+  " Each profile must contain a Setup method
+  " and can contain a Cleanup function.
+  let s:update.profiles = { 'thorough': {}
+        \                 , 'onwrite':  {}
+        \                 }
+
+  " Returns [profile_name, profile].
+  " a:1, if given, will select the profile.
+  " Otherwise, it will default to `g:JSLintUpdateProfile`
+  " unless there is a buffer profile already set.
+  function s:update.GetProfile(...)
+    let profile_name = a:0 ? a:1
+          \ : exists('b:jslint_update_profile') ? b:jslint_update_profile
+          \   : g:JSLintUpdateProfile
+
+    if !exists('self.profiles[profile_name]')
+      throw printf('Non-existent JSLint update profile "%s"', profile_name)
+    endif
+
+    return [profile_name, s:update.profiles[profile_name]]
+  endfunction
+
+  " Change the profile used for this buffer to a new one.
+  " Parameters as GetProfile.
+  " It calls the current profile's cleanup routine if it exists.
+  " Autocommands are cleaned up in addition to the effects of that call.
+  " `b:jslint_update_profile` is updated
+  " with the name of the selected profile.
+  function s:update.SelectProfile(...)
+    let current = self.GetProfile()[1]
+
+    let [profile_name, profile] = call(self.GetProfile, a:000, self)
+
+    if exists('b:jslint_update_profile')
+          \ && b:jslint_update_profile == profile_name
+      return
+    endif
+
+    if exists('b:jslint_update_profile')
+      au! jslint * <buffer>
+      if exists('*current.Cleanup')
+        call current.Cleanup()
+        unlet b:jslint_update_profile
+      endif
+    endif
+
+    try
+      let b:jslint_update_profile = profile_name
+      augroup jslint
+      call profile.Setup()
+    finally
+      augroup END
+    endtry
+  endfunction
+
+  " Profiles
+    function s:update.profiles.thorough.Setup()
+      au BufLeave <buffer> call s:JSLintClear()
+
+      au BufEnter <buffer> call s:JSLint()
+      au InsertLeave <buffer> call s:JSLint()
+      "au InsertEnter <buffer> call s:JSLint()
+      au BufWritePost <buffer> call s:JSLint()
+
+      " due to http://tech.groups.yahoo.com/group/vimdev/message/52115
+      if(!has("win32") || v:version>702)
+        au CursorHold <buffer> call s:JSLint()
+        au CursorHoldI <buffer> call s:JSLint()
+
+        au CursorHold <buffer> call s:GetJSLintMessage()
+      endif
+
+      au CursorMoved <buffer> call s:GetJSLintMessage()
+
+      noremap <buffer><silent> dd dd:JSLintUpdate<CR>
+      noremap <buffer><silent> dw dw:JSLintUpdate<CR>
+      noremap <buffer><silent> u u:JSLintUpdate<CR>
+      noremap <buffer><silent> <C-R> <C-R>:JSLintUpdate<CR>
+    endfunct
+
+    " Handle cleanup except for autocommands
+    function s:update.profiles.thorough.Cleanup()
+      let mappings = ['dd', 'dw', 'u', '<C-R>']
+      for mapping in mappings
+        try
+          exec 'unmap <buffer>' mapping
+        catch /^E31:/
+        endtry
+      endfor
+    endfunction
+
+    function s:update.profiles.onwrite.Setup()
+      au BufWrite <buffer> call s:JSLint()
+
+      au CursorMoved <buffer> call s:GetJSLintMessage()
+    endfunction
+
+
+  " :JSLintUpdateMode
+  " Displays or switches the update profile for this buffer.
+  function s:CompleteUpdateProfiles(...)
+    return join(keys(s:update.profiles), "\n")
+  endfunction
+  command -buffer -complete=custom,s:CompleteUpdateProfiles -nargs=?
+        \ JSLintUpdateMode
+        \ exec <q-args> == ''
+        \   ? 'echo s:update.GetProfile()[0]'
+        \   : 'call s:update.SelectProfile(<f-args>)'
+endif
+
+exec 'JSLintUpdateMode' g:JSLintUpdateProfile
+
 
 if !exists("*s:JSLintUpdate")
   function s:JSLintUpdate()
@@ -43,17 +160,12 @@ if !exists("*s:JSLintUpdate")
   endfunction
 endif
 
-if !exists(":JSLintUpdate")
+if exists(":JSLintUpdate") != 2
   command JSLintUpdate :call s:JSLintUpdate()
 endif
 if !exists(":JSLintToggle")
   command JSLintToggle :let b:jslint_disabled = exists('b:jslint_disabled') ? b:jslint_disabled ? 0 : 1 : 1
 endif
-
-noremap <buffer><silent> dd dd:JSLintUpdate<CR>
-noremap <buffer><silent> dw dw:JSLintUpdate<CR>
-noremap <buffer><silent> u u:JSLintUpdate<CR>
-noremap <buffer><silent> <C-R> <C-R>:JSLintUpdate<CR>
 
 " Set up command and parameters
 if has("win32")


### PR DESCRIPTION
This adds the ability to switch between "update modes" on a per-buffer basis.  Update profiles determine which hooks (autocommands, key mappings) will trigger calls to `JSLint()`, `JSLintClear()`, etc.  I just added one other to the default "thorough" update mode.  There's more info in new comments and in the commit message.

My main motivation for doing this was to avoid issues with quickfix not working.  I determined that removing the `BufEnter` autocommand prevented this issue from occurring, but I couldn't figure out how to remove that without totally changing the way the plugin works.  I ended up setting up a second update profile that only updates on BufWrite events.
### Issue specifics
-   About (maybe exactly) half of the times that JSLint() got run — either via an autocommand or by running `JSLintUpdate` directly — I would have problems using the quickfix list.
-   Subsequently going to a quickfix entry via `:cc`, or by pressing `<Enter>` on the entry in the qf window, or by any other means, I would end up at the wrong line number.  It seemed to be using the wrong quickfix entry: I would end up at a line that was referenced by one of the other quickfix entries.
-   If I disabled JSLint (using `:JSLintToggle`), the stabilized quickfix list would continue to exhibit this behaviour.
-   This issue was readily reproducible.  The line I would end up at seemed to alternate between two different options.  I think that one of the options was always the correct line number.
-   With the stabilized quickfix list in a weird state, I noticed that the return value of `getqflist()` was as expected, and that it matched up with `b:jslint_qf` or whatever it's called.
-   Going to the last entry in the quickfix list seemed to resolve the issue (again, this is with jslint.vim disabled via `:JSLintToggle`).  It would happen again if I re-enabled jslint.vim.
-   Removing the `au BufEnter ...` line in the source code and then restarting vim would result in this issue not occurring.  My guess is that using the quickfix list triggers a BufEnter event and that this results in recursive weirdness somewhere in vim's internals.  It does seem like it's probably a vim issue.

I'm running vim 7.2 with patches 1-330, the current ubuntu 10.10 `vim-gnome` package.  I didn't actually bother to check the patches list to see if there's a resolved issue along these lines, mostly because I'm not about to get my vim from a PPA or build from source just to resolve this.

Anyway, if there is some option or something that fixes this, it would be cool to find out about that.  It seems like some people might want to have update profiles anyway, in case they are editing massive JS scripts and linting with rhino or something.  I personally find that checking on write is enough for me — I save paranoidiacally after each edit of my code anyway.
### style

I'm using dictionary functions and probably some other vaguely recent vim features, hope that's okay.  I didn't start using vim until version 7.something so I'm not very clear on what features were added when, nor on what's an acceptable compatibility target.

There might be some other stylistic issues.  I tried not to clash too hard with what you've got going on in there, but my usual coding style is pretty different from the addon's existing code.  It seems a bit inconsistent anyway, so it seemed like a bit more variety wouldn't hurt too much.  For example, I prefixed the name of a buffer-scope variable with `jslint_` even though this is not being done for most/all of the variables in the addon.  I think probably it should be, since there could be conflict with other addons.
