### PR TITLE
Untitled

### DIFF
--- a/ftplugin/javascript/jslint.vim
+++ b/ftplugin/javascript/jslint.vim
@@ -67,6 +67,8 @@ else
     let s:cmd = '/System/Library/Frameworks/JavaScriptCore.framework/Resources/jsc'
   elseif executable('node')
     let s:cmd = 'node'
+  elseif executable('nodejs')
+    let s:cmd = 'nodejs'
   elseif executable('js')
     let s:cmd = 'js'
   else


### PR DESCRIPTION
- On Ubuntu maverick, node's executable is called nodejs,
  not node.
