### PR TITLE
jslint output was broken on Windows

### DIFF
--- a/ftplugin/javascript/jslint/runjslint.wsf
+++ b/ftplugin/javascript/jslint/runjslint.wsf
@@ -24,14 +24,23 @@ var body = readSTDIN() || arguments[0],
     ok = JSLINT(body),
     i,
     error,
-    errorCount;
+    errorType,
+    nextError,
+    errorCount,
+    WARN = 'WARNING',
+    ERROR = 'ERROR';
 
 if (!ok) {
     errorCount = JSLINT.errors.length;
     for (i = 0; i < errorCount; i += 1) {
         error = JSLINT.errors[i];
+        errorType = WARN;
         if (error && error.reason && error.reason.match(/^Stopping/) === null) {
-            WScript.echo([error.line, error.character, error.reason].join(":"));
+            // If jslint stops next, this was an actual error
+            if (nextError && nextError.reason && nextError.reason.match(/^Stopping/) !== null) {
+                errorType = ERROR;
+            }
+            WScript.echo([error.line, error.character, errorType, error.reason].join(":"));
         }
     }
 }


### PR DESCRIPTION
I updated runjslint.wsf (used on Windows) to output the same thing that runjslint.js does (used everywhere else). jslint.vim was expecting four columns of output and nobody ever updated the wsf file to do so. 
