### PR TITLE
Fix spidermonkey 1.8.5 errors in jslint core

### DIFF
--- a/ftplugin/javascript/jslint/jslint-core.js
+++ b/ftplugin/javascript/jslint/jslint-core.js
@@ -5652,7 +5652,7 @@ loop:   for (;;) {
 }());
 
 if (typeof exports == 'undefined') {
-    exports = {};
+    var exports = {};
 }
 
 exports.JSLINT = JSLINT;


### PR DESCRIPTION
Add a var statement to the declaration of the exports variable at the bottom of
jslint-core.js. Without it, spidermonkey 1.8.5 dies and the plugin becomes
unusable.
