### PR TITLE
Fixed plugin_path for pathogen install.

### DIFF
--- a/bin/jslint
+++ b/bin/jslint
@@ -14,6 +14,9 @@ else
   end
   runjslint_ext = 'js'
   plugin_path = File.join(ENV['HOME'], '.vim')
+  # check for pathogen
+  pathogen_path = File.join(plugin_path, 'bundle', 'jslint')
+  plugin_path = pathogen_path if File.exist?(pathogen_path)
 end
 
 Dir.chdir(File.join(plugin_path, 'ftplugin', 'javascript', 'jslint')) do |dir|


### PR DESCRIPTION
If the jslint plugin is installed via pathogen (normally in
~/.vim/bundle/jslint) then the jslint ruby script won't find the
runjslint scripts. This commit adds a check for a directory
bundle/jslint under the vim configuration folder and sets it as the
plugin root if it exists.
