### PR TITLE
jsc not works on macos, check node before jsc

### DIFF
--- a/ftplugin/javascript/jslint.vim
+++ b/ftplugin/javascript/jslint.vim
@@ -1,4 +1,3 @@
-
 " Global Options
 "
 " Enable/Disable highlighting of errors in source.
@@ -63,10 +62,10 @@ else
   let s:runjslint_ext = 'js'
   if exists("$JS_CMD")
     let s:cmd = "$JS_CMD"
-  elseif executable('/System/Library/Frameworks/JavaScriptCore.framework/Resources/jsc')
-    let s:cmd = '/System/Library/Frameworks/JavaScriptCore.framework/Resources/jsc'
   elseif executable('node')
     let s:cmd = 'node'
+  elseif executable('/System/Library/Frameworks/JavaScriptCore.framework/Resources/jsc')
+    let s:cmd = '/System/Library/Frameworks/JavaScriptCore.framework/Resources/jsc'
   elseif executable('js')
     let s:cmd = 'js'
   else


### PR DESCRIPTION
could not invoke JSLint on mac os, but I have node.
