### PR TITLE
Add interpreters for windows.

### DIFF
--- a/ftplugin/javascript/jslint.vim
+++ b/ftplugin/javascript/jslint.vim
@@ -57,8 +57,15 @@ noremap <buffer><silent> <C-R> <C-R>:JSLintUpdate<CR>
 
 " Set up command and parameters
 if has("win32")
-  let s:cmd = 'cscript /NoLogo '
-  let s:runjslint_ext = 'wsf'
+  let s:runjslint_ext = 'js'
+  if exists("%JS_CMD%")
+    let s:cmd = "$JS_CMD"
+  elseif executable('node')
+    let s:cmd = "node"
+  else
+    let s:cmd = 'cscript /NoLogo '
+    let s:runjslint_ext = 'wsf'
+  endif
 else
   let s:runjslint_ext = 'js'
   if exists("$JS_CMD")
@@ -79,7 +86,11 @@ let s:plugin_path = s:install_dir . "/jslint/"
 if has('win32')
   let s:plugin_path = substitute(s:plugin_path, '/', '\', 'g')
 endif
-let s:cmd = 'cd "' . s:plugin_path . '" && ' . s:cmd . ' "' . s:plugin_path . 'runjslint.' . s:runjslint_ext . '"'
+if has('win32')
+  let s:cmd = '"cd /d "' . s:plugin_path . '" && ' . s:cmd . ' "' . s:plugin_path . 'runjslint.' . s:runjslint_ext . '""'
+else
+  let s:cmd = 'cd "' . s:plugin_path . '" && ' . s:cmd . ' "' . s:plugin_path . 'runjslint.' . s:runjslint_ext . '"'
+endif
 
 let s:jslintrc_file = expand('~/.jslintrc')
 if filereadable(s:jslintrc_file)


### PR DESCRIPTION
Check for JS_CMD (like on other platforms).
Check for node.
Change the s:cmd format to do cd /d (change drive as well as directory) and add quotes around the entire expression. (Without quotes the change directory is run on one process and the interpreter on another).
