### PR TITLE
Various fixes to get jslint.vim working in my dev environment

### DIFF
--- a/ftplugin/javascript/jslint.vim
+++ b/ftplugin/javascript/jslint.vim
@@ -291,6 +291,7 @@ if !exists("*s:ActivateJSLintQuickFixWindow")
         try
             silent colder 9 " go to the bottom of quickfix stack
         catch /E380:/
+        catch /E788:/
         endtry
 
         if s:jslint_qf > 0

--- a/ftplugin/javascript/jslint.vim
+++ b/ftplugin/javascript/jslint.vim
@@ -87,7 +87,7 @@ if has('win32')
   let s:plugin_path = substitute(s:plugin_path, '/', '\', 'g')
 endif
 if has('win32')
-  let s:cmd = '"cd /d "' . s:plugin_path . '" && ' . s:cmd . ' "' . s:plugin_path . 'runjslint.' . s:runjslint_ext . '""'
+  let s:cmd = 'cmd.exe /C "cd /d "' . s:plugin_path . '" && ' . s:cmd . ' "' . s:plugin_path . 'runjslint.' . s:runjslint_ext . '""'
 else
   let s:cmd = 'cd "' . s:plugin_path . '" && ' . s:cmd . ' "' . s:plugin_path . 'runjslint.' . s:runjslint_ext . '"'
 endif


### PR DESCRIPTION
A couple one-line fixes I had to make to get this running on my Windows dev environment:
- Invoking the jslint command using "cmd.exe /C" as "cd" isn't a native command on Windows.
- s:ActivateJSLintQuickFixWindow is now catching an E788 error that was raised due to the way my perforce vim plugin was handling the first change of a read-only file.
