### PR TITLE
Update ftplugin/javascript/jslint.vim

### DIFF
--- a/ftplugin/javascript/jslint.vim
+++ b/ftplugin/javascript/jslint.vim
@@ -1,4 +1,3 @@
-
 " Global Options
 "
 " Enable/Disable highlighting of errors in source.
@@ -247,6 +246,7 @@ let b:showing_message = 0
 
 if !exists("*s:GetJSLintMessage")
   function s:GetJSLintMessage()
+    let b:showing_message = 0 " for Error E121: Undefined variable: b:showing_message 
     let s:cursorPos = getpos(".")
 
     " Bail if RunJSLint hasn't been called yet


### PR DESCRIPTION
Error detected while processing function <SNR>18_JSLintUpdate..<SNR>18_GetJSLintMessage:
line   15:
E121: Undefined variable: b:showing_message
E15: Invalid expression: b:showing_message == 1

I can not execute :JSLintUpdate in vim without this error above, so I declare/define b:showing_message inside s:GetJSLintMessage
