### PR TITLE
Use jslint node module if present.

### DIFF
--- a/ftplugin/javascript/jslint/runjslint.js
+++ b/ftplugin/javascript/jslint/runjslint.js
@@ -4,11 +4,16 @@ var fs, vm, sandbox, jslintCore = 'jslint-core.js';
 
 if (typeof require !== 'undefined') {
     print = require('util').puts;
-    fs = require('fs');
-    vm = require('vm');
-    sandbox = {};
-    res = vm.runInNewContext(fs.readFileSync(jslintCore), sandbox, jslintCore);
-    JSLINT = sandbox.JSLINT;
+    try {
+        JSLINT = require('jslint');
+    }
+    catch( ex ) {
+        fs = require('fs');
+        vm = require('vm');
+        sandbox = {};
+        res = vm.runInNewContext(fs.readFileSync(jslintCore), sandbox, jslintCore);
+        JSLINT = sandbox.JSLINT;
+    }
 } else {
     load('jslint-core.js');
 }


### PR DESCRIPTION
It's nice that the plugin comes with it's own jslint version, but I'd prefer to use the jslint node module if it is installed. Use `jslint-core.js` as fallback.

Why? Sometimes different feature sets get confusing: I would like to obtain the same features calling `jslint` from the terminal and using the vim plugin.

Worked fine so far :)
