### PR TITLE
Don't even try to parse something that is not JS.

### DIFF
--- a/ftplugin/javascript/jslint.vim
+++ b/ftplugin/javascript/jslint.vim
@@ -143,6 +143,9 @@ function! s:JSLint()
   if exists("b:jslint_disabled") && b:jslint_disabled == 1
     return
   endif
+  if !(&filetype == "javascript")
+    return
+  endif
 
   highlight link JSLintError SpellBad
 


### PR DESCRIPTION
Rely on vim's filetype detection and only parse files that are JavaScript.
You probably have something useful in you `.vimrc` file to do something similar. But is there any reason to run jslint for anything other than JavaScript?
