### PR TITLE
Bail out early if no JS interpreter was found!

### DIFF
--- a/ftplugin/javascript/jslint.vim
+++ b/ftplugin/javascript/jslint.vim
@@ -13,7 +13,46 @@ else
   let b:did_jslint_plugin = 1
 endif
 
+" Set up command and parameters
+if has("win32")
+  let s:runjslint_ext = 'js'
+  if exists("%JS_CMD%")
+    let s:cmd = "$JS_CMD"
+  elseif executable('node')
+    let s:cmd = "node"
+  else
+    let s:cmd = 'cscript /NoLogo '
+    let s:runjslint_ext = 'wsf'
+  endif
+else
+  let s:runjslint_ext = 'js'
+  if exists("$JS_CMD")
+    let s:cmd = "$JS_CMD"
+  elseif executable('node')
+    let s:cmd = 'node'
+  elseif executable('nodejs')
+    let s:cmd = 'nodejs'
+  elseif executable('/System/Library/Frameworks/JavaScriptCore.framework/Resources/jsc')
+    let s:cmd = '/System/Library/Frameworks/JavaScriptCore.framework/Resources/jsc'
+  elseif executable('js')
+    let s:cmd = 'js'
+  else
+    echoerr('No JS interpreter found. Checked for jsc, js (spidermonkey), and node')
+    finish
+  endif
+endif
+
 let s:install_dir = expand('<sfile>:p:h')
+
+let s:plugin_path = s:install_dir . "/jslint/"
+if has('win32')
+  let s:plugin_path = substitute(s:plugin_path, '/', '\', 'g')
+endif
+if has('win32')
+  let s:cmd = 'cmd.exe /C "cd /d "' . s:plugin_path . '" && ' . s:cmd . ' "' . s:plugin_path . 'runjslint.' . s:runjslint_ext . '""'
+else
+  let s:cmd = 'cd "' . s:plugin_path . '" && ' . s:cmd . ' "' . s:plugin_path . 'runjslint.' . s:runjslint_ext . '"'
+endif
 
 au BufLeave <buffer> call s:JSLintClear()
 
@@ -55,43 +94,6 @@ noremap <buffer><silent> dd dd:JSLintUpdate<CR>
 noremap <buffer><silent> dw dw:JSLintUpdate<CR>
 noremap <buffer><silent> u u:JSLintUpdate<CR>
 noremap <buffer><silent> <C-R> <C-R>:JSLintUpdate<CR>
-
-" Set up command and parameters
-if has("win32")
-  let s:runjslint_ext = 'js'
-  if exists("%JS_CMD%")
-    let s:cmd = "$JS_CMD"
-  elseif executable('node')
-    let s:cmd = "node"
-  else
-    let s:cmd = 'cscript /NoLogo '
-    let s:runjslint_ext = 'wsf'
-  endif
-else
-  let s:runjslint_ext = 'js'
-  if exists("$JS_CMD")
-    let s:cmd = "$JS_CMD"
-  elseif executable('node')
-    let s:cmd = 'node'
-  elseif executable('nodejs')
-    let s:cmd = 'nodejs'
-  elseif executable('/System/Library/Frameworks/JavaScriptCore.framework/Resources/jsc')
-    let s:cmd = '/System/Library/Frameworks/JavaScriptCore.framework/Resources/jsc'
-  elseif executable('js')
-    let s:cmd = 'js'
-  else
-    echoerr('No JS interpreter found. Checked for jsc, js (spidermonkey), and node')
-  endif
-endif
-let s:plugin_path = s:install_dir . "/jslint/"
-if has('win32')
-  let s:plugin_path = substitute(s:plugin_path, '/', '\', 'g')
-endif
-if has('win32')
-  let s:cmd = 'cmd.exe /C "cd /d "' . s:plugin_path . '" && ' . s:cmd . ' "' . s:plugin_path . 'runjslint.' . s:runjslint_ext . '""'
-else
-  let s:cmd = 'cd "' . s:plugin_path . '" && ' . s:cmd . ' "' . s:plugin_path . 'runjslint.' . s:runjslint_ext . '"'
-endif
 
 let s:jslintrc_file = expand('~/.jslintrc')
 if filereadable(s:jslintrc_file)


### PR DESCRIPTION
Danger! My system's got no JS!

At least some of the machines I'm working on don't have any JS interpreter installed. Sad but true. By shifting a few lines up to the beginning of the `jslint.vim` file and returning early if no interpreter was found, we get one concise error message ("No JS interpreter found. Checked for jsc, js (spidermonkey), and node") instead of this:

```
Error detected while processing /home/jpommerening/.vim/plugin/jslint.vim:
line   83:
No JS interpreter found. Checked for jsc, js (spidermonkey), and node
line   93:
E121: Undefined variable: s:cmd
E15: Invalid expression: 'cd "' . s:plugin_path . '" && ' . s:cmd . ' "' . s:plugin_path . 'runjslint.' . s:runjslint_ext . '"'
Press ENTER or type command to continue
```
