### PR TITLE
Resolve TypeError

### DIFF
--- a/ftplugin/javascript/jslint/jslint-core.js
+++ b/ftplugin/javascript/jslint/jslint-core.js
@@ -2550,7 +2550,6 @@ klass:              do {
         x.thru = 1;
         x.line = 0;
         x.edge = 'edge';
-        s.string = s;
         return postscript(x);
     }
 


### PR DESCRIPTION
I'm running Mac OSX 10.8 and I occasionally get the following error when I open a JS file:

```
Error detected while processing function <SNR>34_JSLint: 
Exception: TypeError: Attempted to assign to readonly property.^@ultimate@jslint-core.js:2553^@@jslint-core.js:3165^@global code@jslint-core.js:6392^@ could not invoke JSLint!
```

Removing line 2553 solved the issue and going through the code it wasn't being used anywhere either.
